### PR TITLE
Replace maps and filters

### DIFF
--- a/fah/Client.py
+++ b/fah/Client.py
@@ -53,7 +53,7 @@ class Client:
 
         # Option names
         names = app.client_option_widgets.keys()
-        self.option_names = map(lambda name: name.replace('_', '-'), names)
+        self.option_names = [name.replace('_', '-') for name in names]
         self.option_names.append('power') # Folding power
 
         # Init commands

--- a/fah/ClientConfig.py
+++ b/fah/ClientConfig.py
@@ -485,7 +485,7 @@ class ClientConfig:
             f.append(r'FS%s' % id)
 
         if len(f):
-            f = map(lambda x: '.*(^|:)%s' % x, f)
+            f = ('.*(^|:)%s' % x for x in f)
             return '(^\*)|(%s):' % ''.join(f)
 
         return None
@@ -497,7 +497,7 @@ class ClientConfig:
 
 
     def log_add_lines(self, app, lines):
-        filtered = filter(self.log_filter, lines)
+        filtered = [line for line in lines if self.log_filter(line)]
 
         if len(filtered):
             text = '\n'.join(filtered)

--- a/fah/Connection.py
+++ b/fah/Connection.py
@@ -50,7 +50,8 @@ class Connection:
         self.init_commands = commands
 
         if self.is_connected():
-            map(self.queue_command, self.init_commands)
+            for cmd in self.init_commands:
+                self.queue_command(cmd)
 
 
     def get_status(self):
@@ -107,7 +108,8 @@ class Connection:
             raise Exception('Connection failed: ' + errno.errorcode[err])
 
         if self.password: self.queue_command('auth "%s"' % self.password)
-        map(self.queue_command, self.init_commands)
+        for cmd in self.init_commands:
+            self.queue_command(cmd)
 
 
     def close(self):

--- a/fah/FAHControl.py
+++ b/fah/FAHControl.py
@@ -408,9 +408,11 @@ class FAHControl(SingleAppServer):
         self.donor_stats_pref = self.preference_widgets['donor_stats']
         self.team_stats_pref = self.preference_widgets['team_stats']
         self.donor_stats_list = builder.get_object('donor_stats_links_list')
-        map(self.donor_stats_list.append, self.donor_stats_links)
+        for x in self.donor_stats_links:
+            self.donor_stats_list.append(x)
         self.team_stats_list = builder.get_object('team_stats_links_list')
-        map(self.team_stats_list.append, self.team_stats_links)
+        for x in self.team_stats_links:
+            self.team_stats_list.append(x)
 
         # OSX integration
         if sys.platform == 'darwin':
@@ -1162,8 +1164,8 @@ class FAHControl(SingleAppServer):
 
     def get_selected_clients(self):
         selection = get_tree_selection(self.client_tree)
-        names = map(lambda item: self.client_list.get(item[1], 0)[0], selection)
-        return set(map(self.clients.get, names))
+        names = (self.client_list.get(item[1], 0)[0] for item in selection)
+        return set(self.clients.get(name) for name in names)
 
 
     def edit_client(self, client):
@@ -1194,8 +1196,7 @@ class FAHControl(SingleAppServer):
     # Slot methods
     def get_selected_slot_ids(self):
         selection = get_tree_selection(self.slot_status_tree)
-        ids = map(lambda x: int(self.slot_status_list.get(x[1], 0)[0]),
-                  selection)
+        ids = [int(self.slot_status_list.get(x[1], 0)[0]) for x in selection]
         return ids
 
 

--- a/fah/db/Table.py
+++ b/fah/db/Table.py
@@ -35,14 +35,14 @@ class Table:
 
         else:
             sql +=\
-                ' AND '.join(map(lambda i: '"%s"=\'%s\'' % i, kwargs.items()))
+                ' AND '.join('"%s"=\'%s\'' % i for i in kwargs.items())
 
         return sql
 
 
     def create(self, db):
         sql = 'CREATE TABLE IF NOT EXISTS "%s" (%s' % (
-            self.name, ','.join(map(Column.get_sql, self.cols)))
+            self.name, ','.join(Column.get_sql(col) for col in self.cols))
 
         if self.constraints: sql += ',%s' % self.constraints
         sql += ')'
@@ -51,24 +51,24 @@ class Table:
 
 
     def insert(self, db, **kwargs):
-        cols = filter(lambda col: col.name in kwargs, self.cols)
+        cols = [col for col in self.cols if col.name in kwargs]
 
         # Error checking
         if len(cols) != len(kwargs):
-            col_names = set(map(Column.get_name, cols))
-            missing = filter(lambda kw: not kw in col_names, kwargs.keys())
+            col_names = set(Column.get_name(col) for col in cols)
+            missing = (kw for kw in kwargs.keys() if not kw in col_names)
             raise Exception('Table %s does not have column(s) %s'
                             % (self.name, ', '.join(missing)))
 
         sql = 'REPLACE INTO "%s" ("%s") VALUES (%s)' % (
-            self.name, '","'.join(map(Column.get_name, cols)),
-            ','.join(map(lambda col: col.get_db_value(kwargs[col.name]), cols)))
+            self.name, '","'.join(Column.get_name(col) for col in cols),
+            ','.join(col.get_db_value(kwargs[col.name]) for col in cols))
 
         db.execute(sql).close()
 
     def select(self, db, cols = None, **kwargs):
         if cols is None:
-            cols = '"' + '","'.join(map(str, self.cols)) + '"'
+            cols = '"' + '","'.join(str(col) for col in self.cols) + '"'
 
         sql = 'SELECT %s FROM %s' % (cols, self.name)
         if 'orderby' in kwargs:


### PR DESCRIPTION
In Python 3, maps and filters return iterators instead of lists. This commit replaces these statements with list comprehensions, generator expressions and for-loops depending on what is actually needed.